### PR TITLE
Add terraform confirmation for plan/apply

### DIFF
--- a/global/atlantis.yaml
+++ b/global/atlantis.yaml
@@ -7,6 +7,7 @@ projects:
       enabled: true
     apply_requirements: [ approved ]
     workspace: dev
+    workflow: custom
 
   - name: stage
     dir: terraform/
@@ -15,6 +16,7 @@ projects:
       enabled: true
     apply_requirements: [ approved ]
     workspace: stage
+    workflow: custom
 
   - name: prod
     dir: terraform/
@@ -23,3 +25,12 @@ projects:
       enabled: true
     apply_requirements: [ approved ]
     workspace: prod
+    workflow: custom
+
+workflows:
+  custom:
+    plan:
+      steps:
+        - init
+        - plan:
+            extra_args: ["-var", "confirm=${WORKSPACE}"]

--- a/global/terraform/confirmation.tf
+++ b/global/terraform/confirmation.tf
@@ -1,0 +1,14 @@
+# See: https://github.com/hashicorp/terraform/issues/25609
+
+variable "confirm" {
+  default = null
+}
+
+output "validate_confirm" {
+  value = null
+
+  precondition {
+    condition     = var.confirm == terraform.workspace
+    error_message = "For confirmation, you must set '${terraform.workspace}' for variable 'confirm' (e.g., 'terraform plan -var confirm=${terraform.workspace}')."
+  }
+}


### PR DESCRIPTION
With _workspaces_ especially, it can be error-prone to know which environment is set. This helps confirm the env.