### PR TITLE
Select all fields in anonymous base tests

### DIFF
--- a/global/spec/support/graphql_shared_context.rb
+++ b/global/spec/support/graphql_shared_context.rb
@@ -8,6 +8,21 @@ module GraphQLSharedContext
 
   let(:allow_unauthenticated?) { false }
 
+  let(:auto_selections) do
+    described_class.fields.map do |name, field|
+      sub_field_for(field).then do |sub_field|
+        if field.connection?
+          "#{name} { nodes #{sub_field} }"
+        else
+          args_for(field).then do |args|
+            args.present? ? "#{name}(#{args}) #{sub_field}" : "#{name} #{sub_field}"
+          end
+        end
+      end
+    end.join(' ')
+  end
+  let(:selections) { auto_selections }
+
   context 'when trying unauthenticated access' do
     let(:context) { {} }
     let(:have_expected_data) { allow_unauthenticated? ? be_truthy : be_nil }
@@ -15,6 +30,7 @@ module GraphQLSharedContext
     let(:expected_code) { allow_unauthenticated? ? nil : failure_code }
     let(:failure_message) { admin? ? /Schema is not configured for (queries|mutations)/ : 'Must be logged in' }
     let(:failure_code) { admin? ? /missing(Query|Mutation)Configuration/ : 'AUTHENTICATION_FAILED' }
+    let(:selections) { auto_selections }
 
     it 'conforms to allow_unauthenticated? for data' do
       expect(data).to have_expected_data

--- a/global/spec/support/graphql_shared_context.rb
+++ b/global/spec/support/graphql_shared_context.rb
@@ -31,17 +31,23 @@ module GraphQLSharedContext
     let(:failure_message) { admin? ? /Schema is not configured for (queries|mutations)/ : 'Must be logged in' }
     let(:failure_code) { admin? ? /missing(Query|Mutation)Configuration/ : 'AUTHENTICATION_FAILED' }
     let(:selections) { auto_selections }
+    let(:errors) do
+      # Treat Viewer as a special case where some fields may require authentication, so only look at top-level errors
+      response_data.fetch(:errors, []).then do |errors|
+        described_class.name == 'Types::Viewer' ? errors.filter { |e| e[:path].count == 1 } : errors
+      end
+    end
 
     it 'conforms to allow_unauthenticated? for data' do
       expect(data).to have_expected_data
     end
 
     it 'conforms to allow_unauthenticated? for errors' do
-      expect(response.dig('errors', 0, 'message')).to match(expected_error)
+      expect(errors.dig(0, :message)).to match(expected_error)
     end
 
     it 'conforms to allow_unauthenticated? for error code' do
-      expect(response.dig('errors', 0, 'extensions', 'code')).to match(expected_code)
+      expect(errors.dig(0, :extensions, :code)).to match(expected_code)
     end
   end
 end

--- a/global/spec/support/graphql_type_context.rb
+++ b/global/spec/support/graphql_type_context.rb
@@ -41,20 +41,6 @@ module GraphQLTypeContext
       { id: record_id, typename: graphql_type }
     end
   end
-  let(:auto_selections) do
-    described_class.fields.map do |name, field|
-      sub_field_for(field).then do |sub_field|
-        if field.connection?
-          "#{name} { nodes #{sub_field} }"
-        else
-          args_for(field).then do |args|
-            args.present? ? "#{name}(#{args}) #{sub_field}" : "#{name} #{sub_field}"
-          end
-        end
-      end
-    end.join(' ')
-  end
-  let(:selections) { auto_selections }
 
   context 'when selecting all fields' do
     let(:selections) { auto_selections }


### PR DESCRIPTION
Our anonymous base tests, determined by `allow_unauthenticated?` in each spec suite, were not selecting all fields which would leave some untested anonymous usage scenarios. This leverages our neato `auto_selections` logic so that these are fully automated tests based on introspection of Type/Mutation fields.