### PR TITLE
Always use 1 replica for dev/stage

### DIFF
--- a/global/helm/templates/deployment.yaml.tt
+++ b/global/helm/templates/deployment.yaml.tt
@@ -4,7 +4,11 @@ kind: Deployment
 metadata:
   name: "{{ .Release.Name }}"
 spec:
-  replicas: {{ .Values.deployment.minReplicas }}
+  {{- if eq .Values.env "prod" }}
+  replicas: 2
+  {{- else }}
+  replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       service: <%= app_name %>

--- a/global/helm/templates/deployment_hpa.yaml
+++ b/global/helm/templates/deployment_hpa.yaml
@@ -8,8 +8,13 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: "{{ .Release.Name }}"
-  minReplicas: {{ .Values.deployment.minReplicas }}
-  maxReplicas: {{ .Values.deployment.maxReplicas }}
+  {{- if eq .Values.env "prod" }}
+  minReplicas: 1
+  maxReplicas: 10
+  {{- else }}
+  minReplicas: 1
+  maxReplicas: 1
+  {{- end }}
   metrics:
     - type: Resource
       resource:

--- a/global/helm/values.yaml
+++ b/global/helm/values.yaml
@@ -1,6 +1,3 @@
 ---
 env: dev
 image: ""
-deployment:
-  minReplicas: 2
-  maxReplicas: 10


### PR DESCRIPTION
This changes our helm charts to have per-deployment replicas and min/max replicas where scaling is turned on. We were previously using `.Values.deployment.<minReplicas/maxReplicas>` which really doesn't make sense for use with every type of deployment across each of our envs. Given how we are using helm charts, adding these per-deployment values in `values.yaml` isn't worth it, so these are now in-lined. We can always temporarily increase replica counts for testing failovers, etc when needed.