### PR TITLE
Tweak k8s resources

### DIFF
--- a/global/helm/templates/deployment.yaml.tt
+++ b/global/helm/templates/deployment.yaml.tt
@@ -22,11 +22,17 @@ spec:
       - name: <%= app_name %>
         image: {{ .Values.image }}
         resources:
-          limits:
-            memory: 700Mi
+          {{- if eq .Values.env "prod" }}
           requests:
             cpu: 200m
+          limits:
             memory: 700Mi
+          {{- else }}
+          requests:
+            cpu: 50m
+          limits:
+            memory: 500Mi
+          {{- end }}
         env:
         - name: AWS_REGION
           value: us-west-2

--- a/global/helm/templates/publish_schema.yaml.tt
+++ b/global/helm/templates/publish_schema.yaml.tt
@@ -27,7 +27,7 @@ spec:
           limits:
             memory: 500Mi
           requests:
-            cpu: 200m
+            cpu: 50m
         env:
         - name: DD_AGENT_HOST
           value: datadog.infrastructure.svc.cluster.local


### PR DESCRIPTION
This changes the default k8s pod resources a bit to be different for prod and non-prod. Non-prod has lower resource requests and limits.