### PR TITLE
Remove CPU requests for non-prod

### DIFF
--- a/global/helm/templates/deployment.yaml.tt
+++ b/global/helm/templates/deployment.yaml.tt
@@ -28,8 +28,6 @@ spec:
           limits:
             memory: 700Mi
           {{- else }}
-          requests:
-            cpu: 50m
           limits:
             memory: 500Mi
           {{- end }}


### PR DESCRIPTION
Even `50m` adds up, so we might as well just remove it for non-prod where we know we won't be needing much CPU.